### PR TITLE
Fix/loader cppcheck

### DIFF
--- a/loader/dbfopen.c
+++ b/loader/dbfopen.c
@@ -416,10 +416,17 @@ DBFOpenLL( const char * pszFilename, const char * pszAccess, SAHooks *psHooks )
 /* -------------------------------------------------------------------- */
     nLenWithoutExtension = DBFGetLenWithoutExtension(pszFilename);
     pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
+    if( pszFullname == SHPLIB_NULLPTR )
+        return SHPLIB_NULLPTR;
     memcpy(pszFullname, pszFilename, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".dbf", 5);
 
     psDBF = STATIC_CAST(DBFHandle, calloc( 1, sizeof(DBFInfo) ));
+    if( psDBF == SHPLIB_NULLPTR )
+    {
+        free( pszFullname );
+        return SHPLIB_NULLPTR;
+    }
     psDBF->fp = psHooks->FOpen( pszFullname, pszAccess );
     memcpy( &(psDBF->sHooks), psHooks, sizeof(SAHooks) );
 
@@ -692,6 +699,8 @@ DBFCreateLL( const char * pszFilename, const char * pszCodePage, SAHooks *psHook
 /* -------------------------------------------------------------------- */
     nLenWithoutExtension = DBFGetLenWithoutExtension(pszFilename);
     pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
+    if( pszFullname == SHPLIB_NULLPTR )
+        return SHPLIB_NULLPTR;
     memcpy(pszFullname, pszFilename, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".dbf", 5);
 
@@ -1972,6 +1981,18 @@ DBFReorderFields( DBFHandle psDBF, int* panMap )
     pachFieldTypeNew = STATIC_CAST(char *, calloc(sizeof(char), psDBF->nFields));
     pszHeaderNew = STATIC_CAST(char*, malloc(sizeof(char) * XBASE_FLDHDR_SZ *
                                   psDBF->nFields));
+
+    if( panFieldOffsetNew == SHPLIB_NULLPTR || panFieldSizeNew == SHPLIB_NULLPTR ||
+        panFieldDecimalsNew == SHPLIB_NULLPTR || pachFieldTypeNew == SHPLIB_NULLPTR ||
+        pszHeaderNew == SHPLIB_NULLPTR )
+    {
+        free( panFieldOffsetNew );
+        free( panFieldSizeNew );
+        free( panFieldDecimalsNew );
+        free( pachFieldTypeNew );
+        free( pszHeaderNew );
+        return FALSE;
+    }
 
     /* shuffle fields definitions */
     for(i=0; i < psDBF->nFields; i++)

--- a/loader/pgsql2shp-core.c
+++ b/loader/pgsql2shp-core.c
@@ -2250,6 +2250,9 @@ quote_identifier(const char *s)
 	char	   *result = malloc(strlen(s) * 2 + 3);
 	char	   *r = result;
 
+	if (result == NULL)
+		return NULL;
+
 	*r++ = '"';
 	while (*s)
 	{

--- a/loader/shp2pgsql-cli.c
+++ b/loader/shp2pgsql-cli.c
@@ -308,6 +308,12 @@ main (int argc, char **argv)
 		char *shp_file = strdup(config->shp_file);
 		char *ptr;
 
+		if ( shp_file == NULL )
+		{
+			fprintf(stderr, "Unable to allocate memory for shapefile name\n");
+			exit(1);
+		}
+
 		/* Remove the extension, if present */
 		for ( ptr = shp_file + strlen(shp_file); ptr > shp_file; ptr-- )
 		{

--- a/loader/shp2pgsql-core.c
+++ b/loader/shp2pgsql-core.c
@@ -531,9 +531,13 @@ FindPolygons(SHPObject *obj, Ring ***Out)
 
 		pt.x = inner->list[0].x;
 		pt.y = inner->list[0].y;
+		pt.z = 0.0;
+		pt.m = 0.0;
 
 		pt2.x = inner->list[1].x;
 		pt2.y = inner->list[1].y;
+		pt2.z = 0.0;
+		pt2.m = 0.0;
 
 		/*
 		* If we assume that the case of the "big polygon w/o hole

--- a/loader/shp2pgsql-gui.c
+++ b/loader/shp2pgsql-gui.c
@@ -913,9 +913,22 @@ create_new_file_config(const char *filename)
 	   type set in set_loader_config_defaults() and each config needs its own copy
 	   of any referenced items */
 	loader_file_config->encoding = strdup(global_loader_config->encoding);
+	if ( loader_file_config->encoding == NULL )
+	{
+		free(loader_file_config);
+		pgui_seterr("Unable to allocate memory for encoding");
+		return 0;
+	}
 
 	/* Copy the filename (we'll remove the .shp extension in a sec) */
 	loader_file_config->shp_file = strdup(filename);
+	if ( loader_file_config->shp_file == NULL )
+	{
+		free(loader_file_config->encoding);
+		free(loader_file_config);
+		pgui_seterr("Unable to allocate memory for filename");
+		return 0;
+	}
 
 	/* Generate the default table name from the filename */
 	table_start = loader_file_config->shp_file + strlen(loader_file_config->shp_file);
@@ -1319,6 +1332,12 @@ pgui_action_open_file_dialog(GtkWidget *widget, gpointer data)
 			filename = g_slist_nth_data(filename_item, 0);
 
 			loader_file_config = create_new_file_config(filename);
+			if (loader_file_config == NULL) {
+					pgui_raise_error_dialogue();
+					g_free(filename);
+				  filename_item = g_slist_next(filename_item);
+					continue;
+			}
 			add_loader_file_config_to_list(loader_file_config);
 
 			/* Grab the next filename */
@@ -2005,6 +2024,12 @@ process_single_uri(char *uri)
 
 	/* Create a new row in the listview */
 	loader_file_config = create_new_file_config(filename);
+	if (loader_file_config == NULL) {
+			pgui_raise_error_dialogue();
+			g_free(filename);
+		  g_free(hostname);
+		  return;
+	}
 	add_loader_file_config_to_list(loader_file_config);
 
 	g_free(filename);
@@ -2622,11 +2647,11 @@ pgui_create_folderchooser_dialog(void)
 }
 
 static void
-pgui_create_progress_dialog()
+pgui_create_progress_dialog(void)
 {
 	GtkWidget *vbox_progress, *table_progress;
 
-	dialog_progress = gtk_dialog_new_with_buttons(_("Working..."), GTK_WINDOW(window_main), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, NULL);
+	dialog_progress = gtk_dialog_new_with_buttons(_("Working..."), GTK_WINDOW(window_main), GTK_DIALOG_DESTROY_WITH_PARENT, "_Cancel", GTK_RESPONSE_CANCEL, NULL);
 
 	gtk_window_set_modal(GTK_WINDOW(dialog_progress), TRUE);
 	gtk_window_set_keep_above(GTK_WINDOW(dialog_progress), TRUE);

--- a/loader/shpopen.c
+++ b/loader/shpopen.c
@@ -367,6 +367,8 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
 /*  Initialize the info structure.                  */
 /* -------------------------------------------------------------------- */
     psSHP = STATIC_CAST(SHPHandle, calloc(sizeof(SHPInfo),1));
+    if( psSHP == SHPLIB_NULLPTR )
+        return SHPLIB_NULLPTR;
 
     psSHP->bUpdated = FALSE;
     memcpy( &(psSHP->sHooks), psHooks, sizeof(SAHooks) );
@@ -377,6 +379,11 @@ SHPOpenLL( const char * pszLayer, const char * pszAccess, SAHooks *psHooks )
 /* -------------------------------------------------------------------- */
     nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
     pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
+    if( pszFullname == SHPLIB_NULLPTR )
+    {
+        free( psSHP );
+        return SHPLIB_NULLPTR;
+    }
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
     psSHP->fpSHP = psSHP->sHooks.FOpen(pszFullname, pszAccess );
@@ -746,6 +753,8 @@ SHPRestoreSHX ( const char * pszLayer, const char * pszAccess, SAHooks *psHooks 
 /* -------------------------------------------------------------------- */
     nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
     pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
+    if( pszFullname == SHPLIB_NULLPTR )
+        return FALSE;
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
     fpSHP = psHooks->FOpen(pszFullname, pszAccess );
@@ -1023,6 +1032,8 @@ SHPCreateLL( const char * pszLayer, int nShapeType, SAHooks *psHooks )
 /* -------------------------------------------------------------------- */
     nLenWithoutExtension = SHPGetLenWithoutExtension(pszLayer);
     pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
+    if( pszFullname == SHPLIB_NULLPTR )
+        return SHPLIB_NULLPTR;
     memcpy(pszFullname, pszLayer, nLenWithoutExtension);
     memcpy(pszFullname + nLenWithoutExtension, ".shp", 5);
     fpSHP = psHooks->FOpen(pszFullname, "wb" );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Added defensive checks and cleanup across loaders to handle memory allocation failures, improving stability under low-memory conditions and preventing leaks.
  - Ensured polygon inner rings consistently include Z/M values, improving geometry consistency in outputs.
  - Command-line tool now fails fast with a clear error when file setup cannot be completed.
  - GUI configuration flow now safely cleans up on allocation failures, avoiding unexpected behavior.

- Style
  - Progress dialog cancel button label updated for clearer UI labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->